### PR TITLE
Fix missing optional in conditional validation documentation

### DIFF
--- a/content/docs/guides/conditional_validation.md
+++ b/content/docs/guides/conditional_validation.md
@@ -53,6 +53,7 @@ You may use a callback with the `requiredWhen` rule to express complex scenarios
 vine.object({
   address: vine
     .string()
+    .optional()
     // highlight-start
     .requiredWhen((field) => {
       if (field.parent.country !== 'USA') {


### PR DESCRIPTION
### 🔗 Linked issue

This was noted by someone on discord, and it was just a missing `.optional()` in the chain: https://discord.com/channels/423256550564691970/423256550564691972/1360644249523323080

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a small error in the documentation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
