### PR TITLE
Fix: incorrect example of otherwise usage in group

### DIFF
--- a/content/docs/types/object.md
+++ b/content/docs/types/object.md
@@ -219,7 +219,7 @@ vine.group([
   })
 ])
 // highlight-start
-.otherwise((field) => {
+.otherwise((_, field) => {
   field.report(
     'You must provide username or email to login',
     'email_or_username',


### PR DESCRIPTION
### 🔗 Linked issue

[#39](https://github.com/vinejs/vinejs.dev/issues/39)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Otherwise need [two parameters](https://github.com/vinejs/vine/blob/3.x/src/types.ts#L248) : value and field. The current example does not seems to work.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
