### PR TITLE
Enhance isMoney rule to ignore optional field

### DIFF
--- a/content/docs/extend/custom_schema_types.md
+++ b/content/docs/extend/custom_schema_types.md
@@ -28,6 +28,14 @@ import { USD } from '@dinero.js/currencies'
 import { FieldContext } from '@vinejs/vine/types'
 
 const isMoneyRule = vine.createRule(function isMoney(value: unknown, _, field: FieldContext) => {
+
+  /**
+   * Ignore optional
+   */
+  if(!field.isDefined){
+    return false
+  }
+
   /**
    * Convert string representation of a number to a JavaScript
    * Number data type.


### PR DESCRIPTION
Added a check for field definition in isMoney rule.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to add a check for optional field definitions in `dataTypeValidator`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
